### PR TITLE
[WIP] Updating nova initial model

### DIFF
--- a/lagrangian_planar/inputs_nova_t7
+++ b/lagrangian_planar/inputs_nova_t7
@@ -2,16 +2,16 @@ problem.model_file = glasner_T7.raw
 
 problem.model_prefix = glasner_T7
 
-problem.nx = 10240
+problem.nx = 15360
 
 problem.model_shift = 4.534384e8
 
 problem.xmin = 0.0
-problem.xmax = 10.240e7
+problem.xmax = 15.36e7
 
 problem.g_const = -7.06e8
 
 problem.temp_cutoff = 1.0e6
 
 problem.low_density_cutoff = 1.e-5
-problem.layer_size = 1.0e7
+problem.layer_size = 2.0e7


### PR DESCRIPTION
In this PR I updated the current initial model parameters to output the one used by model A4 (0.4km of max resolution, extended buffer, and extended isothermal layer).