### PR TITLE
allow for any C/O composition in the core

### DIFF
--- a/sub_chandra/_parameters
+++ b/sub_chandra/_parameters
@@ -13,6 +13,9 @@ X_C12                real         0.00
 # mass fraction of O16 to put in the accreted envelope
 X_O16                real         0.00
 
+# mass fraction of core O16 composition
+core_O16             real         0.5
+
 delta                real         1.e-6
 
 xmin                 real         0.0

--- a/sub_chandra/init_1d.H
+++ b/sub_chandra/init_1d.H
@@ -15,7 +15,6 @@
 
 using namespace amrex;
 
-
 // generate an initial model for an arbitrary-mass, isothermal C WD
 // with an isentropic He envelope on the surface.
 
@@ -36,7 +35,6 @@ AMREX_INLINE void init_1d() {
     const Real TOL_HE_MASS = 1.e-3_rt;
 
     const int MAX_ITER = 1000;
-
 
     // convert the envelope and WD mass into CGS
 
@@ -62,12 +60,11 @@ AMREX_INLINE void init_1d() {
     Real xn_core[NumSpec] = {network_rp::small_x};
     Real xn_he[NumSpec] = {network_rp::small_x};;
 
-    if (problem_rp::mixed_co_wd) {
-        xn_core[ic12] = 0.5_rt - 0.5_rt * (NumSpec - 1) * network_rp::small_x;
-        xn_core[io16] = 0.5_rt - 0.5_rt * (NumSpec - 1) * network_rp::small_x;
-    } else {
-        xn_core[ic12] = 1.0_rt - (NumSpec - 1) * network_rp::small_x;
+    if (problem_rp::core_O16 > 0.0_rt) {
+        xn_core[io16] = problem_rp::core_O16;
     }
+
+    xn_core[ic12] = 1.0_rt - xn_core[io16] - (NumSpec - 2) * network_rp::small_x;
 
     if (problem_rp::X_N14 > 0.0_rt) {
         xn_he[in14] = problem_rp::X_N14;

--- a/sub_chandra/inputs.M_WD-0.9.M_He-0.1.CO.CNO
+++ b/sub_chandra/inputs.M_WD-0.9.M_He-0.1.CO.CNO
@@ -11,8 +11,6 @@ problem.delta = 5.e6
 problem.temp_core = 3.e7
 problem.temp_base = 2.3e8
 
-problem.mixed_co_wd = 1
-
 problem.X_C12 = 0.05
 problem.X_O16 = 0.05
 problem.X_N14 = 0.009

--- a/sub_chandra/inputs.M_WD-0.981.M_He-0.05.CO.CO
+++ b/sub_chandra/inputs.M_WD-0.981.M_He-0.05.CO.CO
@@ -11,8 +11,6 @@ problem.delta = 5.e6
 problem.temp_core = 5.e7
 problem.temp_base = 2.e8
 
-problem.mixed_co_wd = 1
-
 problem.X_C12 = 0.05
 problem.X_O16 = 0.05
 

--- a/sub_chandra/inputs.M_WD-0.981.M_He-0.05.CO.CO.isothermal
+++ b/sub_chandra/inputs.M_WD-0.981.M_He-0.05.CO.CO.isothermal
@@ -11,8 +11,6 @@ problem.delta = 5.e6
 problem.temp_core = 5.e7
 problem.temp_base = 2.e8
 
-problem.mixed_co_wd = 1
-
 problem.X_C12 = 0.05
 problem.X_O16 = 0.05
 

--- a/sub_chandra/inputs.M_WD-1.1.M_He-0.05
+++ b/sub_chandra/inputs.M_WD-1.1.M_He-0.05
@@ -11,7 +11,7 @@ problem.delta = 5.e6
 problem.temp_core = 1.e7
 problem.temp_base = 1.75e8
 
-problem.mixed_co_wd = 0
+problem.core_O16 = 0.0
 
 problem.X_N14 = 0.01
 

--- a/sub_chandra/inputs.M_WD-1.1.M_He-0.05.CO
+++ b/sub_chandra/inputs.M_WD-1.1.M_He-0.05.CO
@@ -11,8 +11,6 @@ problem.delta = 5.e6
 problem.temp_core = 1.e7
 problem.temp_base = 1.75e8
 
-problem.mixed_co_wd = 1
-
 problem.X_N14 = 0.0
 
 problem.low_density_cutoff = 1.e-4

--- a/sub_chandra/inputs.M_WD-1.1.M_He-0.05.CO.N14
+++ b/sub_chandra/inputs.M_WD-1.1.M_He-0.05.CO.N14
@@ -11,8 +11,6 @@ problem.delta = 5.e6
 problem.temp_core = 1.e7
 problem.temp_base = 1.75e8
 
-problem.mixed_co_wd = 1
-
 problem.X_N14 = 0.01
 
 problem.low_density_cutoff = 1.e-4

--- a/sub_chandra/inputs.M_WD-1.1.M_He-0.05.CO.N14.thin
+++ b/sub_chandra/inputs.M_WD-1.1.M_He-0.05.CO.N14.thin
@@ -11,8 +11,6 @@ problem.delta = 1.e6
 problem.temp_core = 1.e7
 problem.temp_base = 1.75e8
 
-problem.mixed_co_wd = 1
-
 problem.X_N14 = 0.01
 
 problem.low_density_cutoff = 1.e-4

--- a/sub_chandra/inputs.M_WD-1.1.M_He-0.05.CO.N14.thinner
+++ b/sub_chandra/inputs.M_WD-1.1.M_He-0.05.CO.N14.thinner
@@ -11,8 +11,6 @@ problem.delta = 2.e5
 problem.temp_core = 1.e7
 problem.temp_base = 1.75e8
 
-problem.mixed_co_wd = 1
-
 problem.X_N14 = 0.01
 
 problem.low_density_cutoff = 1.e-4


### PR DESCRIPTION
Previously, our subchandra initial models have been constrained to either a completely C12 core or 50/50 mixed C/O core. This pr enables us to set up an arbitrary C/O core composition.